### PR TITLE
11 the adafruit mpr121 is not calibrated in the sketch

### DIFF
--- a/Build_Files/Firmware_Files/Musical_Grasping_Training_Aid_Firmware/Musical_Grasping_Training_Aid_Firmware.ino
+++ b/Build_Files/Firmware_Files/Musical_Grasping_Training_Aid_Firmware/Musical_Grasping_Training_Aid_Firmware.ino
@@ -20,27 +20,27 @@
 
 #include <Arduino.h>
 #include <Wire.h>
-#include <DFRobotDFPlayerMini.h>  //MP3 reader library
-#include "Adafruit_MPR121.h"      //Capacitive Touch Sensor library
+#include <DFRobotDFPlayerMini.h>  // MP3 reader library
+#include "Adafruit_MPR121.h"      // Capacitive Touch Sensor library
 
 #ifndef _BV
 #define _BV(bit) (1 << (bit))
 #endif
 
-DFRobotDFPlayerMini myDFPlayer;           //Create  DFPlayer object
-Adafruit_MPR121 cap = Adafruit_MPR121();  //Create MPR121 object
+DFRobotDFPlayerMini myDFPlayer;           // Create  DFPlayer object
+Adafruit_MPR121 cap = Adafruit_MPR121();  // Create MPR121 object
 
-uint16_t currtouched = 0;  //Variable to store capacitance value from MPR121
+uint16_t currtouched = 0;  // Variable to store capacitance value from MPR121
 
 const int buttonPin1 = A0;  // Pin for pushbutton 1
 const int buttonPin2 = A1;  // Pin for pushbutton 2
 
 const int presetVolumes[] = { 5, 8, 11, 14, 17, 20 };  // Preset volume levels
 int currentVolumeIndex = 0;                            // Volume index counter
-int currentSongIndex = 0;                              //Song index counter
+int currentSongIndex = 0;                              // Song index counter
 
-int buttonState1 = 0;  //Variable to store button 1 state
-int buttonState2 = 0;  //Variable to store button 2 state
+int buttonState1 = 0;  // Variable to store button 1 state
+int buttonState2 = 0;  // Variable to store button 2 state
 
 void setup() {
 
@@ -52,8 +52,8 @@ void setup() {
 
   //Wire.begin(); //Initialize I2C communication
 
-  Serial1.begin(9600);        //Setup Serial1 communication; baud rate is 9600 bps
-  while (!Serial) delay(10);  //Wait for Serial1 to initialize
+  Serial1.begin(9600);        // Setup Serial1 communication; baud rate is 9600 bps
+  while (!Serial) delay(10);  // Wait for Serial1 to initialize
   //---MPR121 Capacitive Touch Sensor Test----
   Serial.println("Adafruit MPR121 Capacitive Touch Sensor Test");
 
@@ -66,6 +66,7 @@ void setup() {
       ;
   }
   Serial.println("MPR121 found!");
+  cap.setAutoconfig(true);  // Enable auto calibration for capacitive sensor
 
   //---DFPlayer Test----
   Serial.println("DFRobot DFPlayer Test");

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,12 @@
+Version 1.1 | 2025-Dec-18
+ - Modified firmware to explicitly enable automatic calibration after sensor library change.
+
 Version 1.0 | 2024-Sep-16
  - Added a skip song and volume button
  - Added battery compartment to allow for battery replacement
  - Added slot to access microSD and update/change music files
  - Updated software to incorporate volume and skip song buttons
- - Redesigned the CAD to accomodate updated user interface
+ - Redesigned the CAD to accommodate updated user interface
  - Created and updated standard MMC documentation
 
 


### PR DESCRIPTION
Added cap.setAutoconfig(true) in setup() to enable automatic calibration for the Adafruit MPR121 capacitive touch sensor.